### PR TITLE
fix django admin crash with error "No installed app with label 'util'"

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -826,6 +826,8 @@ INSTALLED_APPS = (
     'openedx.core.djangoapps.coursetalk',  # not used in cms (yet), but tests run
     'xblock_config',
 
+    'util',
+
     # Tracking
     'track',
     'eventtracking.django.apps.EventTrackingConfig',


### PR DESCRIPTION
@amir-qayyum-khan 

During the changes for [CVS export functionality for candidate profile admin models](https://github.com/amir-qayyum-khan/edx-platform/pull/38/) we imported from an app `util` in the module `common`. Since this `common` module is used for both `LMS` and `Studio` so `Studio` django admin was crashing with the error:
```bash
LookupError: No installed app with label 'util'.
```