### PR TITLE
Spelling changed to Powered from powerd

### DIFF
--- a/themes/arbisoft-nda/lms/templates/footer.html
+++ b/themes/arbisoft-nda/lms/templates/footer.html
@@ -3,5 +3,5 @@
 <%namespace name='static' file='static_content.html'/>
 
 <section class="footer-main">
-    Powerd by edX
+    Powered by edX
 </section>


### PR DESCRIPTION
<img width="1272" alt="screen shot 2017-02-16 at 11 07 46 am" src="https://cloud.githubusercontent.com/assets/22347092/23009553/79180748-f438-11e6-8780-04a5f05813e4.png">

Powered was misspelled.