### PR TITLE
add csv generation functionality for student profiles with candidate …

### DIFF
--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -23,6 +23,8 @@ urlpatterns = patterns(
         'instructor.views.api.get_grading_config', name="get_grading_config"),
     url(r'^get_students_features(?P<csv>/csv)?$',
         'instructor.views.api.get_students_features', name="get_students_features"),
+    url(r'^get_students_profile_with_survey(?P<csv>/csv)?$',
+        'instructor.views.api.get_students_profile_with_survey', name="get_students_profile_with_survey"),
     url(r'^get_issued_certificates/$',
         'instructor.views.api.get_issued_certificates', name="get_issued_certificates"),
     url(r'^get_students_who_may_enroll$',

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -563,6 +563,9 @@ def _section_data_download(course, access):
         'get_problem_responses_url': reverse('get_problem_responses', kwargs={'course_id': unicode(course_key)}),
         'get_grading_config_url': reverse('get_grading_config', kwargs={'course_id': unicode(course_key)}),
         'get_students_features_url': reverse('get_students_features', kwargs={'course_id': unicode(course_key)}),
+        'get_students_profile_with_survey_url': reverse(
+            'get_students_profile_with_survey', kwargs={'course_id': unicode(course_key)}
+        ),
         'get_issued_certificates_url': reverse(
             'get_issued_certificates', kwargs={'course_id': unicode(course_key)}
         ),

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -280,6 +280,116 @@ def enrolled_students_features(course_key, features):
     return [extract_student(student, features) for student in students]
 
 
+def enrolled_students_features_with_candidate_survey(course_key, features):
+    """
+    Return a list of student profile features with the candidate survey fields
+    as dictionaries.
+
+    Example:
+        >>> enrolled_students_candidate_profiles(course_key, ['graduation_date', 'cgpa'])
+        [
+            {'username': 'username1', 'first_name': 'firstname1', 'cgpa': '3.30'},
+            {'username': 'username2', 'first_name': 'firstname2', 'cgpa': '3.52'}
+        ]
+    """
+    include_cohort_column = 'cohort' in features
+    include_team_column = 'team' in features
+
+    students = User.objects.filter(
+        courseenrollment__course_id=course_key,
+        courseenrollment__is_active=1,
+    ).order_by('username').select_related('profile')
+
+    if include_cohort_column:
+        students = students.prefetch_related('course_groups')
+
+    if include_team_column:
+        students = students.prefetch_related('teams')
+
+    def extract_attr(student, feature):
+        """
+        Evaluate a student attribute that is ready for JSON serialization.
+        """
+        attr = getattr(student, feature)
+        try:
+            DjangoJSONEncoder().default(attr)
+            return attr
+        except TypeError:
+            return unicode(attr)
+
+    def extract_student(student, features):
+        """
+        Convert student to dictionary.
+        """
+        student_features = [x for x in STUDENT_FEATURES if x in features]
+        profile_features = [x for x in PROFILE_FEATURES if x in features]
+
+        # For data extractions on the 'meta' field
+        # the feature name should be in the format of 'meta.foo' where
+        # 'foo' is the keyname in the meta dictionary
+        meta_features = []
+        for feature in features:
+            if 'meta.' in feature:
+                meta_key = feature.split('.')[1]
+                meta_features.append((feature, meta_key))
+
+        student_dict = dict((feature, extract_attr(student, feature))
+                            for feature in student_features)
+        profile = student.profile
+        if profile is not None:
+            profile_dict = dict((feature, extract_attr(profile, feature))
+                                for feature in profile_features)
+            student_dict.update(profile_dict)
+
+            # now featch the requested meta fields
+            meta_dict = json.loads(profile.meta) if profile.meta else {}
+            for meta_feature, meta_key in meta_features:
+                student_dict[meta_feature] = meta_dict.get(meta_key)
+
+        if include_cohort_column:
+            # Note that we use student.course_groups.all() here instead of
+            # student.course_groups.filter(). The latter creates a fresh query,
+            # therefore negating the performance gain from prefetch_related().
+            student_dict['cohort'] = next(
+                (cohort.name for cohort in student.course_groups.all() if cohort.course_id == course_key),
+                "[unassigned]"
+            )
+
+        if include_team_column:
+            student_dict['team'] = next(
+                (team.name for team in student.teams.all() if team.course_id == course_key),
+                UNAVAILABLE
+            )
+        return student_dict
+
+    def extract_candidate_profile(student, features):
+        """
+        Return candidate survey data as dictionary for the provided student.
+        """
+        if not hasattr(student, 'arbisoft_profile'):
+            return {}
+
+        candidate_profile_meta_features = [
+            field.name for field in student.arbisoft_profile._meta.get_fields()
+        ]
+
+        candidate_profile_features = [x for x in candidate_profile_meta_features if x in features]
+        candidate_profile_dict = dict(
+            (feature, extract_attr(student.arbisoft_profile, feature))
+            for feature in candidate_profile_features
+        )
+        return candidate_profile_dict
+
+    student_features_with_survey_values = []
+    for student in students:
+        features_data = {}
+        features_data.update(extract_student(student, features))
+        features_data.update(extract_candidate_profile(student, features))
+        student_features_with_survey_values.append(features_data)
+
+    return student_features_with_survey_values
+
+
 def list_may_enroll(course_key, features):
     """
     Return info about students who may enroll in a course as a dict.

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -295,6 +295,11 @@ def enrolled_students_features_with_candidate_survey(course_key, features):
     include_cohort_column = 'cohort' in features
     include_team_column = 'team' in features
 
+    include_candidate_courses = 'candidate_courses' in features
+    include_candidate_expertises = 'candidate_expertises' in features
+    include_candidate_technologies = 'candidate_technologies' in features
+    include_candidate_references = 'candidate_references' in features
+
     students = User.objects.filter(
         courseenrollment__course_id=course_key,
         courseenrollment__is_active=1,
@@ -378,6 +383,32 @@ def enrolled_students_features_with_candidate_survey(course_key, features):
             (feature, extract_attr(student.arbisoft_profile, feature))
             for feature in candidate_profile_features
         )
+
+        if include_candidate_courses:
+            candidate_profile_dict['candidate_courses'] = ', '.join(
+                student.arbisoft_profile.candidatecourse_set.all().values_list('studied_course', flat=True)
+            )
+
+        if include_candidate_expertises:
+            candidate_expertises = ', '.join([
+                '{} [Rank {}]'.format(expertise.expertise, expertise.rank)
+                for expertise in student.arbisoft_profile.candidateexpertise_set.all()
+            ])
+            candidate_profile_dict['candidate_expertises'] = candidate_expertises
+
+        if include_candidate_technologies:
+            candidate_technologies = ', '.join(
+                student.arbisoft_profile.candidatetechnology_set.all().values_list('technology', flat=True)
+            )
+            candidate_profile_dict['candidate_technologies'] = candidate_technologies
+
+        if include_candidate_references:
+            candidate_references = ', '.join([
+                '{} [{} | {}]'.format(reference.name, reference.position, reference.phone_number)
+                for reference in student.arbisoft_profile.candidatereference_set.all()
+            ])
+            candidate_profile_dict['candidate_references'] = candidate_references
+
         return candidate_profile_dict
 
     student_features_with_survey_values = []

--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -23,6 +23,7 @@ from instructor_task.tasks import (
     calculate_grades_csv,
     calculate_problem_grade_report,
     calculate_students_features_csv,
+    calculate_students_features_with_survey_csv,
     cohort_students,
     enrollment_report_features_csv,
     calculate_may_enroll_csv,
@@ -344,6 +345,21 @@ def submit_calculate_students_features_csv(request, course_key, features):
     """
     task_type = 'profile_info_csv'
     task_class = calculate_students_features_csv
+    task_input = features
+    task_key = ""
+
+    return submit_task(request, task_type, task_class, course_key, task_input, task_key)
+
+
+def submit_calculate_students_features_with_survey_csv(request, course_key, features):
+    """
+    Submits a task to generate a CSV containing student profile info with
+    survey data.
+
+    Raises AlreadyRunningError if said CSV is already being updated.
+    """
+    task_type = 'profile_with_survey_info_csv'
+    task_class = calculate_students_features_with_survey_csv
     task_input = features
     task_key = ""
 

--- a/lms/djangoapps/instructor_task/tasks.py
+++ b/lms/djangoapps/instructor_task/tasks.py
@@ -38,6 +38,7 @@ from instructor_task.tasks_helper import (
     upload_grades_csv,
     upload_problem_grade_report,
     upload_students_csv,
+    upload_students_profile_with_survey_csv,
     cohort_students_and_upload,
     upload_enrollment_report,
     upload_may_enroll_csv,
@@ -202,6 +203,18 @@ def calculate_students_features_csv(entry_id, xmodule_instance_args):
     # Translators: This is a past-tense verb that is inserted into task progress messages as {action}.
     action_name = ugettext_noop('generated')
     task_fn = partial(upload_students_csv, xmodule_instance_args)
+    return run_main_task(entry_id, task_fn, action_name)
+
+
+@task(base=BaseInstructorTask, routing_key=settings.GRADES_DOWNLOAD_ROUTING_KEY)  # pylint: disable=not-callable
+def calculate_students_features_with_survey_csv(entry_id, xmodule_instance_args):
+    """
+    Compute student profile information with survey for a course and upload
+    the CSV to an S3 bucket for download.
+    """
+    # Translators: This is a past-tense verb that is inserted into task progress messages as {action}.
+    action_name = ugettext_noop('generated')
+    task_fn = partial(upload_students_profile_with_survey_csv, xmodule_instance_args)
     return run_main_task(entry_id, task_fn, action_name)
 
 

--- a/lms/djangoapps/instructor_task/tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tasks_helper.py
@@ -1036,6 +1036,12 @@ def upload_students_profile_with_survey_csv(_xmodule_instance_args, _entry_id, c
     ]
     query_features += candidate_profile_features
 
+    # include candidate profile related features
+    candidate_profile_related_features = [
+        'candidate_courses', 'candidate_expertises', 'candidate_technologies', 'candidate_references'
+    ]
+    query_features += candidate_profile_related_features
+
     # compute the student features table and format it
     student_data = enrolled_students_features_with_candidate_survey(course_id, query_features)
     header, rows = format_dictlist(student_data, query_features)

--- a/lms/djangoapps/instructor_task/tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tasks_helper.py
@@ -52,6 +52,7 @@ from courseware.model_data import DjangoKeyValueStore, FieldDataCache
 from courseware.module_render import get_module_for_descriptor_internal
 from instructor_analytics.basic import (
     enrolled_students_features,
+    enrolled_students_features_with_candidate_survey,
     get_proctored_exam_results,
     list_may_enroll,
     list_problem_responses
@@ -1006,6 +1007,48 @@ def upload_students_csv(_xmodule_instance_args, _entry_id, course_id, task_input
 
     # Perform the upload
     upload_csv_to_report_store(rows, 'student_profile_info', course_id, start_date)
+
+    return task_progress.update_task_state(extra_meta=current_step)
+
+
+def upload_students_profile_with_survey_csv(_xmodule_instance_args, _entry_id, course_id, task_input, action_name):
+    """
+    For a given `course_id`, generate a CSV file containing profile
+    information with survey for all students that are enrolled, and store
+    using a `ReportStore`.
+    """
+    start_time = time()
+    start_date = datetime.now(UTC)
+    enrolled_students = CourseEnrollment.objects.users_enrolled_in(course_id)
+    task_progress = TaskProgress(action_name, enrolled_students.count(), start_time)
+
+    current_step = {'step': 'Calculating Profile Info With Survey Data'}
+    task_progress.update_task_state(extra_meta=current_step)
+
+    query_features = task_input
+
+    # include candidate profile features
+    candidate_profile_features = [
+        'graduation_date', 'phone_number', 'cgpa', 'position_in_class', 'academic_projects',
+        'extra_curricular_activities', 'freelance_work', 'accomplishment', 'individuality_factor',
+        'ideal_organization', 'why_arbisoft', 'expected_salary', 'career_plan', 'other_studied_course',
+        'other_technology'
+    ]
+    query_features += candidate_profile_features
+
+    # compute the student features table and format it
+    student_data = enrolled_students_features_with_candidate_survey(course_id, query_features)
+    header, rows = format_dictlist(student_data, query_features)
+    task_progress.attempted = task_progress.succeeded = len(rows)
+    task_progress.skipped = task_progress.total - task_progress.attempted
+
+    rows.insert(0, header)
+
+    current_step = {'step': 'Uploading Profile Info With Survey Data CSV'}
+    task_progress.update_task_state(extra_meta=current_step)
+
+    # Perform the upload
+    upload_csv_to_report_store(rows, 'student_profile_info_with_survey_data', course_id, start_date)
 
     return task_progress.update_task_state(extra_meta=current_step)
 

--- a/lms/static/coffee/src/instructor_dashboard/data_download.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/data_download.coffee
@@ -74,6 +74,7 @@ class DataDownload
     # gather elements
     @$list_studs_btn = @$section.find("input[name='list-profiles']")
     @$list_studs_csv_btn = @$section.find("input[name='list-profiles-csv']")
+    @$list_students_survey_csv_btn = @$section.find("input[name='list-profiles-with-survey-csv']")
     @$list_proctored_exam_results_csv_btn = @$section.find("input[name='proctored-exam-results-report']")
     @$survey_results_csv_btn = @$section.find("input[name='survey-results-report']")
     @$list_may_enroll_csv_btn = @$section.find("input[name='list-may-enroll-csv']")
@@ -160,6 +161,26 @@ class DataDownload
         url: url
         error: (std_ajax_err) =>
           @$reports_request_response_error.text gettext("Error generating student profile information. Please try again.")
+          $(".msg-error").css({"display":"block"})
+        success: (data) =>
+          @$reports_request_response.text data['status']
+          $(".msg-confirm").css({"display":"block"})
+
+    # this handler binds to download profile with survey csv button
+    @$list_students_survey_csv_btn.click (e) =>
+      @clear_display()
+
+      url = @$list_students_survey_csv_btn.data 'endpoint'
+      # handle csv special case
+      # redirect the document to the csv file.
+      url += '/csv'
+
+      $.ajax
+        type: 'POST'
+        dataType: 'json'
+        url: url
+        error: (std_ajax_err) =>
+          @$reports_request_response_error.text gettext("Error generating student profile with survey information. Please try again.")
           $(".msg-error").css({"display":"block"})
         success: (data) =>
           @$reports_request_response.text data['status']

--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -32,6 +32,10 @@ from openedx.core.djangolib.markup import HTML, Text
 
     <p><input type="button" name="list-profiles-csv" value="${_("Download profile information as a CSV")}" data-endpoint="${ section_data['get_students_features_url'] }" data-csv="true"></p>
 
+    <p>${_("Click to generate a CSV file of all students enrolled in this course, along with profile information and survey data, e.g. email address, username, cgpa, expected salary:")}</p>
+
+    <p><input type="button" name="list-profiles-with-survey-csv" value="${_("Download profile with survey information as a CSV")}" data-endpoint="${ section_data['get_students_profile_with_survey_url'] }" data-csv="true"></p>
+
     <p>${_("Click to generate a CSV file that lists learners who can enroll in the course but have not yet done so.")}</p>
 
     <p><input type="button" name="list-may-enroll-csv" value="${_("Download a CSV of learners who can enroll")}" data-endpoint="${ section_data['get_students_who_may_enroll_url'] }" data-csv="true"></p>


### PR DESCRIPTION
…survey
@amir-qayyum-khan 

**Fixes:** https://github.com/amir-qayyum-khan/edx-platform/issues/28
This PR adds CSV generation functionality for enrolled student profiles with the candidate survey data.

Add a new button with label `Download profile with survey information as a CSV` on `Instructor Dashboard` to tirgger CSV generation with enrolled student profile data with candidate survey info.
<img width="823" alt="screen shot 2017-02-16 at 1 35 12 pm" src="https://cloud.githubusercontent.com/assets/5072991/23013531/de88b8b6-f44c-11e6-8718-46e431ef1eba.png">


**Why not update the existing functionality for `Download profile information as a CSV`?**

Because it might break some other modules dependent on it and it would also break the tests (unittests, automation tests etc). Since we are customizing the `Open edX` for Arbisoft, so we should atleast try not to break existing functionality and unittests. As for the new custom modules we can always add unittest to include the new changes in coverage.

**Why provide candidate profile features fields in the method `upload_students_profile_with_survey_csv` instead of the base method `get_students_profile_with_survey`?**

The base method `get_students_profile_with_survey` submits a celery task by providing all fields (which we want in the CSV) as `task_input` and this parameter `task_input` has limitation of `255` characters. Since length of all fields (student profile + candidate profile) were reaching the size ~`450` it was throwing error:
```
ValueError: Task input longer than 255: "["id", "username", "name", "email", "language", "location", "year_of_birth", "gender", "level_of_education", "mailing_address", "goals", "city", "country", ["graduation_date", "phone_number", "cgpa", "position_in_class", "academic_projects", "extra_curricular_activities", "freelance_work", "accomplishment", "individuality_factor", "ideal_organization", "why_arbisoft", "expected_salary", "career_plan", "other_studied_course", "other_technology"]]" for "profile_with_survey_info_csv" of "course-v1:edX+DemoX+Demo_Course"
``` 

**Why candidate profile fields, e.g. `'graduation_date', 'phone_number', 'cgpa'` are empty for some of the users?**

Because those users haven't submitted the candidate survey form so they don't have candidate profiles.

**Why you didn't cleaned/refactored some of the duplicate code?**

Due to short time and making the new changes consistent with existing code :)

**Did I enjoyed creating this PR?**

Very much. I always wanted to modify the edX codebase without any unittest. 😆 